### PR TITLE
Fix crash when user doesn't allow contacts permission

### DIFF
--- a/Classes/Invite/Providers/AddressBook/BranchInviteTextContactProvider.m
+++ b/Classes/Invite/Providers/AddressBook/BranchInviteTextContactProvider.m
@@ -123,7 +123,9 @@
         [self loadContactsFromAddressBook:addressBook callback:callback];
     }
     else {
-        CFRelease(addressBook);
+        if (addressBook != nil) {
+            CFRelease(addressBook);
+        }
         callback(NO, nil);
     }
 }


### PR DESCRIPTION
### Problem:

App crashes when the user doesn't allow contacts permission 


### Solution: 

check if addressBook is null before releasing it as per doc 

```
If cf is NULL, this will cause a runtime error and your application will crash.
```
